### PR TITLE
v0.8.1.8 ys 메인 완료

### DIFF
--- a/src/main/java/com/choongang/erpproject/main/dto/MainResponseDto.java
+++ b/src/main/java/com/choongang/erpproject/main/dto/MainResponseDto.java
@@ -14,6 +14,7 @@ public class MainResponseDto {
     private String levType;
 
     //공지사항 제목, 작성일자
+    private int ntcNum;
     private String title;
     private String date;
 }

--- a/src/main/resources/static/js/main/main.js
+++ b/src/main/resources/static/js/main/main.js
@@ -127,10 +127,13 @@ function getNoticeDash() {
         if(!json.length) {
             html = '<td colspan="3"> 등록된 공지사항이 없습니다.</td>';
         } else {
-            json.forEach((obj, idx) => {
+            json.forEach((obj) => {
+
+                var num = obj.ntcNum;
+
                 html += `
-                <tr>
-                    <td>${idx+1}</td>
+                <tr style="cursor:pointer;" onclick="location.href='http://localhost:8080/info/viewinfo?ntcNum='+${num}" onmouseover="this.style.background='whitesmoke'" onmouseout="this.style.background='white'" >
+                    <td>${num}</td>
                     <td>${obj.title}</td>
                     <td>${obj.date}</td>
                 </tr>

--- a/src/main/resources/static/mapper/MainMapper.xml
+++ b/src/main/resources/static/mapper/MainMapper.xml
@@ -45,7 +45,7 @@
     </select>
 
     <select id="getNoticeDash" resultType="MainResponseDto">
-        SELECT title, SUBSTRING(date, 1, 10) AS date
+        SELECT ntc_num, title, SUBSTRING(date, 1, 10) AS date
         FROM notice
         ORDER BY ntc_num DESC LIMIT 10;
     </select>


### PR DESCRIPTION
 - 달력 2차 구현 완료(이름 + 휴가 구분)
 - 메인 내 콘텐츠 추가 
1) 당월 입사자 현황
2) 전체 직원 수 현황
3) 결제 대기 현황
4) 미니 공지사항(링크 추가)